### PR TITLE
Add creatureTraits

### DIFF
--- a/data/traits.json
+++ b/data/traits.json
@@ -645,5 +645,576 @@
 			"page": 638,
 			"srd": true
 		}
+	],
+	"creatureTrait (uses source: BST) (MAY REFERENCE SOURCES THAT DO NOT EXIST [missing Lost Omens for example])": [
+		{
+			"name": "Soulbound",
+			"source": "BST",
+			"entries": [
+				"These constructs are mentally augmented by a fragment of a once-living creature’s soul."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Mummy",
+			"source": "BST",
+			"entries": [
+				"A mummy is an undead creature created from a preserved corpse."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Gnoll",
+			"source": "BST",
+			"entries": [
+				"Gnolls are humanoids that resemble hyenas."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Tiefling",
+			"source": "BST",
+			"entries": [
+				"A creature with this trait has the tiefling versatile heritage. Tieflings are planar scions descended from {@trait fiend|BST|fiends}. An ability with this trait can be used or selected only by tieflings."
+			],
+			"page": 270,
+			"srd": true
+		},
+		{
+			"name": "Tengu",
+			"source": "BST",
+			"entries": [
+				"A creature with this trait is a member of the tengu ancestry. Tengus are humanoids who resemble birds. An ability with this trait can be used or selected only by tengus. An item with this trait is created and used by tengus."
+			],
+			"page": 270,
+			"srd": true
+		},
+		{
+			"name": "Incorporeal",
+			"source": "BST",
+			"entries": [
+				"An incorporeal creature or object has no physical form. It can pass through solid objects, including walls. When inside an object, an incorporeal creature can’t perceive, attack, or interact with anything outside the object, and if it starts its turn in an object, it is {@condition slowed|crb} 1. Corporeal creatures can pass through an incorporeal creature, but they can’t end their movement in its space.",
+				"An incorporeal creature can’t attempt Strength-based checks against physical creatures or objects—only against incorporeal ones—unless those objects have the ghost touch property rune. Likewise, a corporeal creature can’t attempt Strength-based checks against incorporeal creatures or objects.",
+				"Incorporeal creatures usually have immunity to effects or conditions that require a physical body, like disease, poison, and precision damage. They usually have resistance against all damage (except force damage and damage from Strikes with the ghost touch property rune), with double the resistance against non-magical damage."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Swarm",
+			"source": "BST",
+			"entries": [
+				"A swarm is a mass or cloud of creatures that functions as one monster. Its size entry gives the size of the entire mass, though for most swarms the individual creatures that make up that mass are Tiny. A swarm can occupy the same space as other creatures, and must do so in order to use its damaging action. A swarm typically has weakness to effects that deal damage over an area (like area spells and splash weapons)."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Mutant",
+			"source": "BST",
+			"entries": [
+				"The monster has mutated or evolved, granting it unusual benefits, drawbacks, or both."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Caligni",
+			"source": "BST",
+			"entries": [
+				"These subterranean people have darkvision, and some have powers to create darkness."
+			],
+			"page": 345,
+			"srd": true
+		},
+		{
+			"name": "Elf",
+			"source": "CRB",
+			"entries": [
+				"A creature with this trait is a member of the elf ancestry. Elves are mysterious people with rich traditions of magic and scholarship who typically have low-light vision. An ability with this trait can be used or selected only by elves. A weapon with this trait is created and used by elves."
+			],
+			"page": 631,
+			"srd": true
+		},
+		{
+			"name": "Aasimar",
+			"source": "APG",
+			"entries": [
+				"A creature with this trait has the aasimar versatile heritage. Aasimars are planar scions descended from celestial beings. An ability with this trait can be used or selected only by aasimars."
+			],
+			"page": 266,
+			"srd": true
+		},
+		{
+			"name": "Sprite",
+			"source": "BST",
+			"entries": [
+				"A family of diminutive winged fey with a strong connection to primal magic."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Cold",
+			"source": "BST",
+			"entries": [
+				"Effects with this trait deal cold damage. Creatures with this trait have a connection to magical cold."
+			],
+			"page": 629,
+			"srd": true
+		},
+		{
+			"name": "Wight",
+			"source": "BST",
+			"entries": [
+				""
+			],
+			"page": 332,
+			"srd": true
+		},
+		{
+			"name": "Aquatic",
+			"source": "BST",
+			"entries": [
+				"Aquatic creatures are at home underwater. Their bludgeoning and slashing unarmed Strikes don’t take the usual –2 penalty for being underwater. Aquatic creatures can breathe water but not air."
+			],
+			"page": 345,
+			"srd": true
+		},
+		{
+			"name": "Devil",
+			"source": "CRB",
+			"entries": [
+				"A family of fiends from Hell, most devils are irredeemably lawful evil. They typically have greater darkvision, immunity to fire, and telepathy."
+			],
+			"page": 630,
+			"srd": true
+		},
+		{
+			"name": "Kobold",
+			"source": "APG",
+			"entries": [
+				"A creature with this trait is a member of the kobold ancestry. Kobolds are reptilian humanoids who are usually Small and typically have darkvision. An ability with this trait can be used or selected only by kobolds."
+			],
+			"page": 268,
+			"srd": true
+		},
+		{
+			"name": "Ratfolk",
+			"source": "APG",
+			"entries": [
+				"A creature with this trait is a member of the ratfolk ancestry. Ratfolk are humanoids who resemble rats. An ability with this trait can be used or selected only by ratfolk."
+			],
+			"page": 269,
+			"srd": true
+		},
+		{
+			"name": "Psychopomp",
+			"source": "BST",
+			"entries": [
+				"A family of monitors spawned within the Boneyard to convey souls to the Outer Planes, most psychopomps are true neutral. They typically have darkvision, lifesense, and spirit touch, and they are immune to death effects."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Leshy",
+			"source": "LOCG",
+			"entries": [
+				"Leshies are living plants animated by primal magic."
+			],
+			"page": 133,
+			"srd": true
+		},
+		{
+			"name": "Hag",
+			"source": "CRB",
+			"entries": [
+				"These creatures are malevolent spellcasters who form covens."
+			],
+			"page": 632,
+			"srd": true
+		},
+		{
+			"name": "Wraith",
+			"source": "BST",
+			"entries": [
+				""
+			],
+			"page": 335,
+			"srd": true
+		},
+		{
+			"name": "Genie",
+			"source": "BST",
+			"entries": [
+				"The diverse families of genies hold positions of prominence on the Elemental Planes. They have powerful magical abilities."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Gremlin",
+			"source": "BST",
+			"entries": [
+				"Cruel and mischievous fey, gremlins have acclimated to life on the Material Plane."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Orc",
+			"source": "BST",
+			"entries": [
+				"A creature with this trait is a member of the orc ancestry. These green-skinned people tend to have darkvision. An ability with this trait can be used or selected only by orcs. An item with this trait is created and used by orcs."
+			],
+			"page": 634,
+			"srd": true
+		},
+		{
+			"name": "Azata",
+			"source": "CRB",
+			"entries": [
+				"This family of celestials is native to Elysium. They are typically chaotic good and have darkvision and a weakness to evil and cold iron."
+			],
+			"page": 629,
+			"srd": true
+		},
+		{
+			"name": "Ghoul",
+			"source": "BST",
+			"entries": [
+				"Ghouls are vile undead creatures that feast on flesh."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Dinosaur",
+			"source": "CRB",
+			"entries": [
+				"These reptiles have survived from prehistoric times."
+			],
+			"page": 630,
+			"srd": true
+		},
+		{
+			"name": "Vampire",
+			"source": "BST",
+			"entries": [
+				"Undead creatures who thirst for blood, vampires are notoriously versatile and hard to destroy."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Daemon",
+			"source": "BST",
+			"entries": [
+				"A family of fiends spawned on the desolate plane of Abaddon, most daemons are neutral evil. They typically have darkvision and weakness to good damage."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Aeon",
+			"source": "BST",
+			"entries": [
+				"These monitors are the self-styled defenders of reality. Traditional aeons have dualistic natures and forms, and they hold a dichotomy of interests, though axiomites and inevitables do not. Aeons other than axiomites and inevitables communicate via a strange telepathic hodgepodge of sensory sending called envisioning."
+			],
+			"page": 345,
+			"srd": true
+		},
+		{
+			"name": "Boggard",
+			"source": "BST",
+			"entries": [
+				"Boggards are frog-like humanoids. They typically have darkvision."
+			],
+			"page": 345,
+			"srd": true
+		},
+		{
+			"name": "Demon",
+			"source": "BST",
+			"entries": [
+				"A family of {@trait fiend|BST|fiends}, demons hail from or trace their origins to the Abyss. Most are irredeemably chaotic evil and have darkvision."
+			],
+			"page": 123,
+			"srd": true
+		},
+		{
+			"name": "Mindless",
+			"source": "CRB",
+			"entries": [
+				"A mindless creature has either programmed or rudimentary mental attributes. Most, if not all, of their mental ability modifiers are –5. They are immune to all mental effects."
+			],
+			"page": 634,
+			"srd": true
+		},
+		{
+			"name": "Human",
+			"source": "CRB",
+			"entries": [
+				"A creature with this trait is a member of the human ancestry. Humans are a diverse array of people known for their adaptability. An ability with this trait can be used or selected only by humans."
+			],
+			"page": 633,
+			"srd": true
+		},
+		{
+			"name": "Catfolk",
+			"source": "APG",
+			"entries": [
+				"A creature with this trait is a member of the catfolk ancestry. Catfolk are humanoids with feline features. An ability with this trait can be used or selected only by catfolk. An item with this trait is created and used by catfolk."
+			],
+			"page": 266,
+			"srd": true
+		},
+		{
+			"name": "Changeling",
+			"source": "BST",
+			"entries": [
+				"A creature with this trait has the changeling versatile heritage. Changelings are the children of {@trait hag|BST|hags} and members of other humanoid ancestries. An ability with this trait can be used or selected only by changelings."
+			],
+			"page": 123,
+			"srd": true
+		},
+		{
+			"name": "Golem",
+			"source": "BST",
+			"entries": [
+				"Golems are a special type of construct. Golems are immune to almost all magic, but most have a weakness to certain spells."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Alchemical",
+			"source": "CRB",
+			"entries": [
+				"Alchemical items are powered by reactions of alchemical reagents. Alchemical items aren’t magical and don’t radiate a magical aura."
+			],
+			"page": 628,
+			"srd": true
+		},
+		{
+			"name": "Archon",
+			"source": "CRB",
+			"entries": [
+				"Members of this family of celestials are the protectors of Heaven and are lawful good. They have darkvision and a weakness to evil damage."
+			],
+			"page": 628,
+			"srd": true
+		},
+		{
+			"name": "Lizardfolk",
+			"source": "LOCG",
+			"entries": [
+				"These reptilian humanoids, also known as iruxi, are extremely adaptable and patient."
+			],
+			"page": 133,
+			"srd": true
+		},
+		{
+			"name": "Nymph",
+			"source": "BST",
+			"entries": [
+				"This family of beautiful fey creatures has strong ties to natural locations."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Dero",
+			"source": "BST",
+			"entries": [
+				"This family of humanoids are the descendants of fey creatures that fell into darkness and confusion after being abandoned in the Darklands. They are immune to confusion and vulnerable to sunlight."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Skeleton",
+			"source": "BST",
+			"entries": [
+				"This undead is made by animating a dead creature’s skeleton with negative energy."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Zombie",
+			"source": "BST",
+			"entries": [
+				"These undead are mindless rotting corpses that hunger for living flesh."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Ghost",
+			"source": "BST",
+			"entries": [
+				"Lost souls that haunt the world as incorporeal undead are called ghosts."
+			],
+			"page": 346,
+			"srd": true
+		},
+		{
+			"name": "Rakshasa",
+			"source": "BST",
+			"entries": [
+				"Reincarnations of evil souls, rakshasas are fiends that live on the Material Plane."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Amphibious",
+			"source": "BST",
+			"entries": [
+				"An amphibious creature can breathe in water and in air, even outside of its preferred environment, usually indefinitely but at least for hours. These creatures often have a swim Speed. Their bludgeoning and slashing unarmed Strikes don’t take the usual –2 penalty for being underwater."
+			],
+			"page": 345,
+			"srd": true
+		},
+		{
+			"name": "Xulgath",
+			"source": "BST",
+			"entries": [
+				"These subterranean reptilian creatures tend to have darkvision and smell awful."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Angel",
+			"source": "CRB",
+			"entries": [
+				"This family of celestials is native to the plane of Nirvana. Most angels are neutral good, have darkvision, and have a weakness to evil damage."
+			],
+			"page": 628,
+			"srd": true
+		},
+		{
+			"name": "Drow",
+			"source": "CRB",
+			"entries": [
+				"Subterranean kin of the elves, drow typically have darkvision and inborn magical abilities."
+			],
+			"page": 631,
+			"srd": true
+		},
+		{
+			"name": "Duergar",
+			"source": "CRB",
+			"entries": [
+				"Subterranean kin of the dwarves, duergar typically have darkvision and immunity to poison. They are not easily fooled by illusions."
+			],
+			"page": 631,
+			"srd": true
+		},
+		{
+			"name": "Duskwalker",
+			"source": "APG",
+			"entries": [
+				"A creature with this trait has the duskwalker versatile heritage. Duskwalkers are planar scions infused with the supernatural energy of psychopomps. An ability with this trait can be used or selected only by duskwalkers."
+			],
+			"page": 267,
+			"srd": true
+		},
+		{
+			"name": "Dhampir",
+			"source": "APG",
+			"entries": [
+				"A creature with this trait has the dhampir versatile heritage. These humanoids are the immortal offspring of vampires and members of other ancestries."
+			],
+			"page": 267,
+			"srd": true
+		},
+		{
+			"name": "Merfolk",
+			"source": "BST",
+			"entries": [
+				"These aquatic humanoids have an upper body similar to a human and a lower body similar to a fish."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Inevitable",
+			"source": "BST",
+			"entries": [
+				"These constructed aeons were created by the axiomites. Each type of inevitable is dedicated to a specific task. Most inevitables have weakness to chaotic damage."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Dwarf",
+			"source": "CRB",
+			"entries": [
+				"A creature with this trait is a member of the dwarf ancestry. Dwarves are stout folk who often live underground and typically have darkvision. An ability with this trait can be used or selected only by dwarves. An item with this trait is created and used by dwarves."
+			],
+			"page": 631,
+			"srd": true
+		},
+		{
+			"name": "Werecreature",
+			"source": "BST",
+			"entries": [
+				"These shapechanging creatures either are naturally able to shift between animal, humanoid, and hybrid forms or are afflicted with a curse that forces them to shift involuntarily."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Troll",
+			"source": "BST",
+			"entries": [
+				"Trolls are giant, brutish creatures and are well known for their ability to regenerate."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Protean",
+			"source": "BST",
+			"entries": [
+				"A family of monitors spawned within the Maelstrom, these creatures are guardians of disorder and are chaotic neutral. They typically have darkvision, an amorphous anatomy, and a weakness to lawful damage."
+			],
+			"page": 347,
+			"srd": true
+		},
+		{
+			"name": "Sea",
+			"source": "BST",
+			"entries": [
+				"YYY"
+			],
+			"page": 123,
+			"srd": true
+		},
+		{
+			"name": "Gnome",
+			"source": "CRB",
+			"entries": [
+				"A creature with this trait is a member of the gnome ancestry. Gnomes are small people skilled at magic who seek out new experiences and usually have low-light vision. An ability with this trait can be used or selected only by gnomes. A weapon with this trait is created and used by gnomes."
+			],
+			"page": 632,
+			"srd": true
+		},
+		{
+			"name": "Goblin",
+			"source": "CRB",
+			"entries": [
+				"A creature with this trait can come from multiple tribes of creatures, including goblins, hobgoblins, and bugbears. Goblins tend to have darkvision. An ability with this trait can be used or chosen only by goblins. A weapon with this trait is created and used by goblins."
+			],
+			"page": 632,
+			"srd": true
+		}
 	]
 }


### PR DESCRIPTION
LOCG - Lost Omens Character Guide

Some tags reference the _missing_ fiend trait for it not being on the given list.