### PR TITLE
add human

### DIFF
--- a/data/ancestries/ancestry-human.json
+++ b/data/ancestries/ancestry-human.json
@@ -10,6 +10,7 @@
 			"boosts": [
 				"Two free ability boosts"
 			],
+			"flaw": "\u2014",
 			"languages": [
 				"Common",
 				"Additional languages equal to your Intelligence modifier (if it’s positive). Choose from the list of common languages and any other languages to which you have access (such as the languages prevalent in your region)."
@@ -18,6 +19,12 @@
 				"Human",
 				"Humanoid"
 			],
+			"feature": {
+				"name": "",
+				"entries": [
+					""
+				]
+			},
 			"flavor": [
 				"As unpredictable and varied as any of Golarion’s peoples, humans have exceptional drive and the capacity to endure and expand. Though many civilizations thrived before humanity rose to prominence, humans have built some of the greatest and the most terrible societies throughout the course of history, and today they are the most populous people in the realms around the Inner Sea."
 			],
@@ -47,7 +54,7 @@
 						{
 							"type": "list",
 							"items": [
-								"Respect your flexibility, your adaptability, and\u2014in most cases\u2014your open-mindedness.",
+								"Respect your flexibility, your adaptability, and--in most cases--your open-mindedness.",
 								"Distrust your intentions, fearing you seek only power or wealth.",
 								"Aren’t sure what to expect from you and are hesitant to assume your intentions."
 							]
@@ -104,7 +111,7 @@
 						{
 							"type": "pf2-sidebar",
 							"page": 55,
-							"name": "Other Halves",
+							"name": "OTHER HALVES",
 							"entries": [
 								"By default, half-elves and half-orcs descend from humans, but your GM might allow you to be the offspring of an elf, orc, or different ancestry. In these cases, the GM will let you select the half-elf or half-orc heritage as the heritage for this other ancestry. The most likely other parent of a half-elf are gnomes and halflings, and the most likely parents of a half-orc are goblins, halflings, and dwarves."
 							]

--- a/data/ancestries/ancestry-human.json
+++ b/data/ancestries/ancestry-human.json
@@ -10,7 +10,6 @@
 			"boosts": [
 				"Two free ability boosts"
 			],
-			"flaw": "\u2014",
 			"languages": [
 				"Common",
 				"Additional languages equal to your Intelligence modifier (if it’s positive). Choose from the list of common languages and any other languages to which you have access (such as the languages prevalent in your region)."
@@ -19,12 +18,6 @@
 				"Human",
 				"Humanoid"
 			],
-			"feature": {
-				"name": "",
-				"entries": [
-					""
-				]
-			},
 			"flavor": [
 				"As unpredictable and varied as any of Golarion’s peoples, humans have exceptional drive and the capacity to endure and expand. Though many civilizations thrived before humanity rose to prominence, humans have built some of the greatest and the most terrible societies throughout the course of history, and today they are the most populous people in the realms around the Inner Sea."
 			],

--- a/data/ancestries/ancestry-human.json
+++ b/data/ancestries/ancestry-human.json
@@ -1,0 +1,243 @@
+{
+	"ancestry": [
+		{
+			"name": "Human",
+			"source": "CRB",
+			"page": 54,
+			"HP": 8,
+			"size": "Medium",
+			"speed": 25,
+			"boosts": [
+				"Two free ability boosts"
+			],
+			"languages": [
+				"Common",
+				"Additional languages equal to your Intelligence modifier (if it’s positive). Choose from the list of common languages and any other languages to which you have access (such as the languages prevalent in your region)."
+			],
+			"traits": [
+				"Human",
+				"Humanoid"
+			],
+			"flavor": [
+				"As unpredictable and varied as any of Golarion’s peoples, humans have exceptional drive and the capacity to endure and expand. Though many civilizations thrived before humanity rose to prominence, humans have built some of the greatest and the most terrible societies throughout the course of history, and today they are the most populous people in the realms around the Inner Sea."
+			],
+			"info": [
+				"Humans’ ambition, versatility, and exceptional potential have led to their status as the world’s predominant ancestry. Their empires and nations are vast, sprawling things, and their citizens carve names for themselves with the strength of their sword arms and the power of their spells. Humanity is diverse and tumultuous, running the gamut from nomadic to imperial, sinister to saintly. Many of them venture forth to explore, to map the expanse of the multiverse, to search for long-lost treasure, or to lead mighty armies to conquer their neighbors—for no better reason than because they can.",
+				"If you want a character who can be just about anything, you should play a human.",
+				{
+					"type": "pf2-h3",
+					"page": 54,
+					"name": "You Might...",
+					"entries": [
+						{
+							"type": "list",
+							"items": [
+								"Strive to achieve greatness, either in your own right or on behalf of a cause.",
+								"Seek to understand your purpose in the world.",
+								"Cherish your relationships with family and friends."
+							]
+						}
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 54,
+					"name": "Others Probably...",
+					"entries": [
+						{
+							"type": "list",
+							"items": [
+								"Respect your flexibility, your adaptability, and\u2014in most cases\u2014your open-mindedness.",
+								"Distrust your intentions, fearing you seek only power or wealth.",
+								"Aren’t sure what to expect from you and are hesitant to assume your intentions."
+							]
+						}
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 54,
+					"name": "Physical Description",
+					"entries": [
+						"Humans’ physical characteristics are as varied as the world’s climes. Humans have a wide variety of skin and hair colors, body types, and facial features. Generally speaking, their skin has a darker hue the closer to the equator they or their ancestors lived.",
+						"Humans reach physical adulthood around the age of 15, though mental maturity occurs a few years later. A typical human can live to be around 90 years old. Humans often intermarry with people of other ancestries, giving rise to children who bear the traits of both parents. The most notable half-humans are half-elves and half-orcs."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 54,
+					"name": "Society",
+					"entries": [
+						"Human variety also manifests in terms of their governments, attitudes, and social norms. Though the oldest of human cultures can trace their shared histories thousands of years into the past, when compared to the societies of the elves or dwarves, human civilizations seem in a state of constant flux as empires fragment and new kingdoms subsume the old."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 54,
+					"name": "Alignment and Religion",
+					"entries": [
+						"Humanity is perhaps the most heterogeneous of all the ancestries, with a capacity for great evil and boundless good. Some humans assemble into vast raging hordes, while others build sprawling cities. Considered as a whole, most humans are neutral, yet they tend to congregate into nations or communities of a shared alignment, or at least a shared tendency toward an alignment. Humans also worship a wide range of gods and practice many different religions, tending to seek favor from any divine being they encounter."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 54,
+					"name": "Names",
+					"entries": [
+						"Unlike many ancestral cultures, which generally cleave to specific traditions and shared histories, humanityfs diversity has resulted in a near-infinite set of names. The humans of northern tribes have different names than those dwelling in southern nation.states. Humans throughout much of the world speak Common (though some continents on Golarion have their own regional common languages), yet their names are as varied as their beliefs and appearances."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 55,
+					"name": "Ethnicities",
+					"entries": [
+						"A variety of human ethnic groups\u2014many of which have origins on distant lands\u2014populates the continents bordering Golarion’s Inner Sea. Human characters can be any of these ethnicities, regardless of what lands they call home. Information about Golarion’s human ethnicities appears on page 430 in Chapter 8.",
+						"Characters of human ethnicities in the Inner Sea region speak Common (also known as Taldane), and some ethnicities grant access to an uncommon language."
+					]
+				},
+				{
+					"type": "pf2-h2",
+					"page": 55,
+					"name": "Half-Elves",
+					"entries": [
+						{
+							"type": "pf2-sidebar",
+							"page": 55,
+							"name": "Other Halves",
+							"entries": [
+								"By default, half-elves and half-orcs descend from humans, but your GM might allow you to be the offspring of an elf, orc, or different ancestry. In these cases, the GM will let you select the half-elf or half-orc heritage as the heritage for this other ancestry. The most likely other parent of a half-elf are gnomes and halflings, and the most likely parents of a half-orc are goblins, halflings, and dwarves."
+							]
+						},
+						"A half-elf is born to an elf and a human, or to two half-elves. The life of a half-elf can be difficult, often marked by a struggle to fit in. Half-elves don’t have their own homeland on Golarion, nor are populations of half-elves particularly tied to one another, since they often have very disparate human and elven traditions. Instead, most half-elves attempt to find acceptance in either human or elven settlements.",
+						"Half-elves often appear primarily human, with subtly pointed ears and a taller stature than most full-blooded humans. Half-elves lack the almost alien eyes of their elf parents, though they do have a natural presence\u2014and often a striking beauty\u2014that leads many to become artists or entertainers. Despite this innate appeal, many half.elves have difficulty forming lasting bonds with either humans or elves due to the distance they feel from both peoples as a whole.",
+						"Half-elves live longer than other humans, often reaching an age around 150 years. This causes some of them to fear friendship and romance with humans, knowing that they’ll likely outlive their companions."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 55,
+					"name": "Playing a Half-Elf",
+					"entries": [
+						"You can create a half-elf character by selecting the half-elf heritage at 1st level. This gives you access to elf and half-elf ancestry feats in addition to human ancestry feats."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 55,
+					"name": "You Might...",
+					"entries": [
+						{
+							"type": "list",
+							"items": [
+								"Keep to yourself and find it difficult to form close bonds with others.",
+								"Strongly embrace or reject one side or the other of your parentage.",
+								"Identify strongly with and relate to other people with mixed ancestries."
+							]
+						}
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 55,
+					"name": "Others Probably...",
+					"entries": [
+						{
+							"type": "list",
+							"items": [
+								"Find you more attractive than humans and more approachable than elves.",
+								"Dismiss your human ethnicity and culture in light of your elven heritage.",
+								"Downplay the challenges of being caught between two cultures."
+							]
+						}
+					]
+				},
+				{
+					"type": "pf2-h2",
+					"page": 55,
+					"name": "Half-Orcs",
+					"entries": [
+						"A half-orc is the offspring of a human and an orc, or of two half-orcs. Because some intolerant people see orcs as more akin to monsters than people, they sometimes hate and fear half-orcs simply due to their lineage. This commonly pushes half-orcs to the margins of society, where some find work in manual labor or as mercenaries, and others fall into crime or cruelty. Many who can’t stand the indignities heaped on them in human society find a home among their orc kin or trek into the wilderness to live in peace, apart from society’s judgment.",
+						"Humans often assume half-orcs are unintelligent or uncivilized, and half-orcs rarely find acceptance among societies with many such folk. To an orc tribe, a half-orc is considered smart enough to make a good war leader but weaker physically than other orcs. Many half-orcs thus end up having low status among orc tribes unless they can prove their strength.",
+						"A half-orc has a shorter lifespan than other humans, living to be roughly 70 years old."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 56,
+					"name": "Playing a Half-Orc",
+					"entries": [
+						"You can create a half-orc character by selecting the half-orc heritage at 1st level. This gives you access to orc and half-orc ancestry feats in addition to human ancestry feats."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 56,
+					"name": "You Might...",
+					"entries": [
+						{
+							"type": "list",
+							"items": [
+								"Ignore, embrace, or actively counter the common stereotypes about half-orcs.",
+								"Make the most of your size and strength, either physically or socially.",
+								"Keep your distance from people of most other ancestries, in case they unfairly reject you due to your orc ancestors."
+							]
+						}
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"page": 56,
+					"name": "Others Probably...",
+					"entries": [
+						{
+							"type": "list",
+							"items": [
+								"Assume you enjoy and excel at fighting but aren’t inclined toward magical or intellectual pursuits.",
+								"Pity you for the tragic circumstances they assume were involved in your birth.",
+								"Get out of your way and back down rather than face your anger."
+							]
+						}
+					]
+				}
+			],
+			"heritageInfo": [
+				"Unlike other ancestries, humans don’t have significant physiological differences defined by their lineage. Instead, their heritages either reveal their potential as a people or reflect lineages from multiple ancestries. Choose one of the following human heritages at 1st level."
+			],
+			"heritage": [
+				{
+					"name": "Half-Elf",
+					"source": "CRB",
+					"page": 56,
+					"entries": [
+						"Either one of your parents was an elf, or one or both were half-elves. You have pointed ears and other telltale signs of elf heritage. You gain the elf trait and low-light vision. In addition, you can select elf, half-elf, and human feats whenever you gain an ancestry feat."
+					]
+				},
+				{
+					"name": "Half-Orc",
+					"source": "CRB",
+					"page": 56,
+					"entries": [
+						"One of your parents was an orc, or one or both were half-orcs. You have a green tinge to your skin and other indicators of orc heritage. You gain the orc trait and low-light vision. In addition, you can select orc, half-orc, and human feats whenever you gain an ancestry feat."
+					]
+				},
+				{
+					"name": "Skilled Heritage",
+					"source": "CRB",
+					"page": 56,
+					"entries": [
+						"Your ingenuity allows you to train in a wide variety of skills. You become trained in one skill of your choice. At 5th level, you become an expert in the chosen skill."
+					]
+				},
+				{
+					"name": "Versatile Heritage",
+					"source": "CRB",
+					"page": 56,
+					"entries": [
+						"Humanity’s versatility and ambition have fueled its ascendance to be the most common ancestry in most nations throughout the world. Select a general feat of your choice for which you meet the prerequisites (as with your ancestry feat, you can select this general feat at any point during character creation)."
+					]
+				}
+			]
+		}
+	]
+}

--- a/data/ancestries/index.json
+++ b/data/ancestries/index.json
@@ -4,5 +4,6 @@
 	"gnome": "ancestry-gnome.json",
 	"goblin": "ancestry-goblin.json",
 	"halfling": "ancestry-halfling.json",
+	"human": "ancestry-human.json",
 	"versatileHeritage": "versatile-heritages.json"
 }


### PR DESCRIPTION
Notes:
- Included half-elves and half-orcs in the same way they're done in the CRB. Could potentially have them as their own entries, or have their info show only if the relevant heritage is selected? Went with matching CRB for now
- Put the 'Other Halves' sidebar in the half-elves section because that seemed to look the best/make the most sense. To try and match the CRB it could go with half-orcs, or I could try putting it with the other sidebar info at the top