### PR TITLE
Afflictions work

### DIFF
--- a/data/afflictions.json
+++ b/data/afflictions.json
@@ -594,7 +594,7 @@
 						"DC": 16,
 						"saving throw": "Will",
 						"effect": [
-							"You must rest for 12 hours instead of 8 to avoid becoming fatigued and can’t gain any benefits from resting or long‑term rest. You can still make your daily preparations."
+							"You must rest for 12 hours instead of 8 to avoid becoming {@condition fatigued} and can’t gain any benefits from resting or long‑term rest. You can still make your daily preparations."
 						]
 					}
 				}

--- a/data/afflictions.json
+++ b/data/afflictions.json
@@ -37,7 +37,541 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Scarlet Fever",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 1,
+			"traits": [
+				"Disease"
+			],
+			"entries": [
+				"The relatively simple sore throat caused by this disease leads many victims to initially dismiss it as a mild illness, but scarlet fever can be deadly if left untreated. You can’t reduce your sickened condition while affected with scarlet fever.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 13,
+						"saving throw": "Fortitude",
+						"onset": "2 days",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition sickened||sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition sickened||sickened 2}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition sickened||sickened 3} and can't speak",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "death"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Tetanus",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 1,
+			"traits": [
+				"Disease"
+			],
+			"entries": [
+				"An infection introduced through open wounds, tetanus can produce stiffness, muscle spasms strong enough to break bones, and ultimately death.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 14,
+						"saving throw": "Fortitude",
+						"onset": "10 days",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition clumsy||clumsy 1}",
+								"duration": "1 week"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition clumsy||clumsy 2} and can't speak",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition paralyzed} with spasms",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "death"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Tuberculosis",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 1,
+			"traits": [
+				"Disease"
+			],
+			"entries": [
+				"An extended respiratory disease, tuberculosis can pose particular challenges to spellcasters and some performers due to the intense coughing fits it produces.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 15,
+						"saving throw": "Fortitude",
+						"onset": "1 week",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "carrier with no effects",
+								"duration": "1 week"
+							},
+							{
+								"stage": 2,
+								"entry": "coughing requires you to succeed at a DC 5 flat check to Cast a Spell with a verbal component or Activate an Item with a command component",
+								"duration": "1 week"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition fatigued}, can’t recover from the fatigued condition, and coughing requires a successful DC 15 flat check to Cast a Spell with a verbal component or Activate an Item with a command component",
+								"duration": "1 week"
+							},
+							{
+								"stage": 4,
+								"entry": "{@condition unconscious}",
+								"duration": "1 week"
+							},
+							{
+								"stage": 5,
+								"entry": "death"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Malaria",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 2,
+			"traits": [
+				"Disease"
+			],
+			"entries": [
+				"A pernicious disease spread by bloodsucking insects, malaria sometimes enters long periods of dormancy. If you succumb to malaria, you may continue to be periodically affected by the disease, even if you’re cured. You can’t reduce your sickened condition while affected with malaria.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 16,
+						"saving throw": "Fortitude",
+						"onset": "10 days",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition sickened||sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition sickened||sickened 2}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition sickened||sickened 2}, and disease recurs every {@dice 1d4} months even if cured",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "unconscious",
+								"duration": "1 day"
+							},
+							{
+								"stage": 5,
+								"entry": "death"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Bubonic Plague",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 3,
+			"traits": [
+				"Disease"
+			],
+			"entries": [
+				"This widespread illness can sweep through entire communities, leaving few unaffected. The first indication of the disease is a telltale swelling of glands. In some cases, the disease can move into your lungs (pneumonic plague) or blood (septicemic plague), which is even more fatal. If you have bubonic plague, you can’t remove the fatigued condition while affected.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 17,
+						"saving throw": "Fortitude",
+						"onset": "1 day",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition fatigued}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition enfeebled||enfeebled 2} and {@condition fatigued}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition enfeebled||enfeebled 3}, {@condition fatigued}, and take {@dice 1d6} persistent bleed damage every {@dice 1d20} minutes",
+								"duration": "1 day"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Scarlet Leprosy",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 4,
+			"traits": [
+				"Disease",
+				"Virulent"
+			],
+			"entries": [
+				"Scarlet leprosy is widely feared for its devastating effects, crushing bones and organs while making recovery nearly impossible. Damage taken from scarlet leprosy can’t be healed until the disease is cured.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 19,
+						"saving throw": "Fortitude",
+						"onset": "1 day",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@dice 2d6} bludgeoning damage",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@dice 2d6} bludgeoning damage, and whenever you gain the {@condition wounded} condition, increase the condition value by 1",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@dice 4d6} bludgeoning damage and can’t heal any Hit Point damage",
+								"duration": "1 day"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Bone Chill",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 5,
+			"traits": [
+				"Disease",
+				"Necromancy",
+				"Primal"
+			],
+			"entries": [
+				"If you are wounded and exposed to persistent cold, you might contract bonechill.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 20,
+						"saving throw": "Fortitude",
+						"onset": "1 day",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition clumsy|| clumsy 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition clumsy|| clumsy 2} and can't heal cold damage until this disease is cured",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition clumsy|| clumsy 3} and all cold temperature effects are one step more severe for the victim ({@book {@i Core Rulebook} 517|CRB|10|Temperature})",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "{@condition paralyzed} and all cold temperature effects are one step more severe for the victim",
+								"duration": "1 day"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Chocking Death",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 118,
+			"level": 6,
+			"traits": [
+				"Disease"
+			],
+			"entries": [
+				"This disease is capable of wiping out nations or even entire continents. A few pockets of the disease still remain in Iobaria, keeping that region’s population sparse.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 22,
+						"saving throw": "Fortitude",
+						"onset": "1 day",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "hoarse voice but no other symptoms",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition drained|| drained 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition drained|| drained 2} and can't speak",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "death"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Blinding Sickness",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 119,
+			"level": 7,
+			"traits": [
+				"Disease"
+			],
+			"entries": [
+				"Endemic to jungles of the Mwangi Expanse, blinding sickness is transmitted by dirty water or the bites of certain creatures.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 23,
+						"saving throw": "Fortitude",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "carrier with no effects",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition enfeebled|| enfeebled 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition enfeebled|| enfeebled 2}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "{@condition enfeebled|| enfeebled 2} and permanently blinded",
+								"duration": "1 day"
+							},
+							{
+								"stage": 5,
+								"entry": "{@condition enfeebled|| enfeebled 4}"
+							},
+							{
+								"stage": 6,
+								"entry": "death"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Sewer Haze",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 119,
+			"level": 7,
+			"traits": [
+				"Disease",
+				"Virulent"
+			],
+			"entries": [
+				"Many healers and alchemists suspect that sewer haze has a supernatural origin, given its association with particularly strong otyughs.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 23,
+						"saving throw": "Fortitude",
+						"onset": "2 days",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition stupefied|| stupefied 2}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition drained|| drained 2} and {@condition stupefied|| stupefied 2}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition drained|| drained 3} and {@condition stupefied|| stupefied 3}",
+								"duration": "1 day"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Nightmare Fever",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 119,
+			"level": 8,
+			"traits": [
+				"Disease",
+				"Necromancy",
+				"Occult"
+			],
+			"entries": [
+				"Thought to be caused by a night hag’s curse, nightmare fever inflicts you with terrible nightmares, and you awaken with the wounds you received in your dreams. Some versions cause you to dream of being wounded by bludgeoning or piercing weapons, in which case you take that type of damage instead. Damage and the fatigued condition caused by the disease can’t be healed until the disease is removed.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 25,
+						"saving throw": "Will",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@dice 2d6} slashing damage and {@condition fatigued}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@dice 4d6} slashing damage and {@condition fatigued}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@dice 4d6} slashing damage, {@condition fatigued}, and whenever you take slashing damage, you must succeed at a Will save against the disease’s DC or become {@condition frightened||frightened 2}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "{@dice 6d6} slashing damage, {@condition fatigued}, and whenever you take slashing damage, you must succeed at a Will save against the disease’s DC or become {@condition paralyzed}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 5,
+								"entry": "{@dice 6d6} slashing damage and {@condition unconscious}"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Brain Worms",
+			"type": "Disease",
+			"source": "GMG",
+			"page": 119,
+			"level": 11,
+			"traits": [
+				"Disease",
+				"Virulent"
+			],
+			"entries": [
+				"Scholars suspect these brain parasites have an otherworldly or extraplanar origin. Though transmitted by the bites of infected targets, the disease remains relatively rare—most hosts are killed by the effects before they can pass it on. While infected, whenever you attack due to confusion, you bite your target (if you don’t have a jaws or fangs attack, you deal piercing damage as an unarmed attack with damage equal to your lowest unarmed attack).",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 28,
+						"saving throw": "Fortitude",
+						"onset": "1 day",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition stupefied||stupefied 2}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition stupefied||stupefied 2}, and whenever you take damage, you must succeed at a Will save against the disease’s DC or become {@condition confused} for 1 round",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition stupefied||stupefied 3}, and whenever you take damage, you must succeed at a Will save against the disease’s DC or become {@condition confused} for 1 minute",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "{@condition stupefied||stupefied 4} and {@condition confused}, damage does not end the confused condition",
+								"duration": "1 day"
+							},
+							{
+								"stage": 5,
+								"entry": "{@condition unconscious}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 6,
+								"entry": "death"
+							}
+						]
+					}
+				}
+			]
 		}
+
+
 	],
 	"curse": [
 		{

--- a/data/afflictions.json
+++ b/data/afflictions.json
@@ -5,7 +5,7 @@
 			"type": "Disease",
 			"source": "GMG",
 			"page": 118,
-			"level": "Level Varies",
+			"level": 0,
 			"traits": [
 				"Disease"
 			],
@@ -595,6 +595,394 @@
 						"saving throw": "Will",
 						"effect": [
 							"You must rest for 12 hours instead of 8 to avoid becoming fatigued and can’t gain any benefits from resting or long‑term rest. You can still make your daily preparations."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Theft of Thought",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 116,
+			"level": 3,
+			"traits": [
+				"Curse",
+				"Enchantment",
+				"Magical",
+				"Mental"
+			],
+			"entries": [
+				"This curse protects a single book and activates against any creature who {@action steal||Steals} it.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 18,
+						"saving throw": "Will",
+						"effect": [
+							"You begin to lose details from your memories, as well as a portion of your procedural memory. After being cursed, the first time you attempt a check using a skill in which you are trained or better, your proficiency rank in the skill used decreases by one rank for as long as you are cursed."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Slayer's Haunt",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 116,
+			"level": 4,
+			"traits": [
+				"Curse",
+				"Illusion",
+				"Magical",
+				"Visual"
+			],
+			"entries": [
+				"You are haunted by all those you have killed.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 19,
+						"saving throw": "Will",
+						"effect": [
+							"You see all creatures around you as those you have slain, still bearing their wounds. You can’t identify, {@action Recall Knowledge} about, or otherwise interact with these creatures in any way that involves seeing their true form without first succeeding at a Will save against the curse’s DC to see through the illusion. On a critical failure for such a Will save, you become {@condition frightened||frightened 1}."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Coward's Roots",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 116,
+			"level": 4,
+			"traits": [
+				"Curse",
+				"Enchantment",
+				"Fear",
+				"Magical",
+				"Mental"
+			],
+			"entries": [
+				"You find all courage stolen from your heart. When faced with something frightening, you flee in terror or stand frozen in place.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 20,
+						"saving throw": "Will",
+						"effect": [
+							"At the start of your turn, if you are {@condition frightened}, you become your choice of {@condition immobilized} or {@condition fleeing} until the end of that turn."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Curse of the Ravenous",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 116,
+			"level": 5,
+			"traits": [
+				"Curse",
+				"Magical",
+				"Transmutation"
+			],
+			"entries": [
+				"This hideous curse kills through constant hunger. You become gaunt and repeatedly gnash your teeth.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 20,
+						"saving throw": "Fortitude",
+						"effect": [
+							"No matter how much you eat, you aren’t satiated. After 1 day, you begin starving ({@book {@i Core Rulebook} 500|CRB|10|Starvation and Thirst}). Each week, you receive a new saving throw against the curse."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Wizard's Ward",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 116,
+			"level": 6,
+			"traits": [
+				"Abjuration",
+				"Curse",
+				"Magical"
+			],
+			"entries": [
+				"A wizard’s ward is placed upon a single book, usually a spellbook. If you damage the book, you must attempt a save against the curse’s effect.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 22,
+						"saving throw": "Will",
+						"effect": [
+							"You take {@dice 5d6} damage of the same damage type as the damage you dealt to the book, and the damage can’t be healed as long as the curse lasts. Repairing the book, including replacing any missing text, ends this curse."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Oath of the Flesh",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 7,
+			"traits": [
+				"Abjuration",
+				"Curse",
+				"Magical"
+			],
+			"entries": [
+				"When you swear an oath, you must obey that oath or suffer terrible consequences.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 23,
+						"saving throw": "Fortitude",
+						"effect": [
+							"Each time you make a promise to someone, an ornate symbol representing that promise is magically carved into your flesh. Breaking any of these promises causes the symbol tattoo to grow into a gaping wound, dealing {@dice 3d6} slashing damage to you; damage from the curse can’t be healed as long as the curse is still in effect."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Sellsword's Folly",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 9,
+			"traits": [
+				"Curse",
+				"Emotion",
+				"Enchantment",
+				"Magical",
+				"Mental"
+			],
+			"entries": [
+				"Even the most experienced combat veteran becomes as reckless as a rookie when suffering from sellsword’s folly.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 26,
+						"saving throw": "Will",
+						"effect": [
+							"The chaos of combat overwhelms you. Each time you roll initiative for a combat encounter, you must attempt a new saving throw against the curse; on a failure, you become {@condition confused} for 1 round. This is an {@trait incapacitation} effect."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Curse of Slumber",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 11,
+			"traits": [
+				"Curse",
+				"Incapacitation",
+				"Magical",
+				"Necromancy",
+				"Sleep"
+			],
+			"entries": [
+				"This legendary curse sends you into a sleep indistinguishable from death.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 28,
+						"saving throw": "Fortitude",
+						"effect": [
+							"You fall asleep for 1 round (or permanently on a critical failure) and seem to be dead; a creature must succeed at a DC 30 Medicine check to realize you are alive. Noise doesn’t awaken you, but taking damage gives you a new saving throw against the curse."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Reviling Earth",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 12,
+			"traits": [
+				"Curse",
+				"Death",
+				"Magical",
+				"Necromancy"
+			],
+			"entries": [
+				"A reviling earth curse usually appears across a specific geographical region, such as a ruined town, a necromancer’s domain, or a similar area.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 30,
+						"saving throw": "Fortitude",
+						"effect": [
+							"When you enter the area, you become {@condition doomed||doomed 1}, or {@condition doomed||doomed 2} on a critical failure."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Spirit Anchor",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 13,
+			"traits": [
+				"Curse",
+				"Magical",
+				"Necromancy",
+				"Negative"
+			],
+			"entries": [
+				"This curse prevents your soul from moving on after death.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 31,
+						"saving throw": "Fortitude",
+						"effect": [
+							"If you die while affected, your spirit is anchored to the Material Plane, and you become a ghost or other incorporeal undead."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Unending Thirst",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 15,
+			"traits": [
+				"Curse",
+				"Transmutation",
+				"Magical"
+			],
+			"entries": [
+				"This curse kills through dehydration in the same vein as the curse of the ravenous, but with deadly speed.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 32,
+						"saving throw": "Fortitude",
+						"effect": [
+							"You gain no benefit from drinking water or other liquids and begin suffering from thirst ({@book {@i Core Rulebook} 500|CRB|10|Starvation and Thirst}). Each day, you receive a new saving throw against the curse."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Reviled of Nature",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 18,
+			"traits": [
+				"Curse",
+				"Emotion",
+				"Enchantment",
+				"Magical",
+				"Mental"
+			],
+			"entries": [
+				"This curse makes the hunter into the hunted, drawing the ire of animals wherever you go.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 38,
+						"saving throw": "Will",
+						"effect": [
+							"Creatures of the natural world abhor you. Whenever an animal becomes aware of you, it must attempt a Will save against the curse. On a failure, it attacks you and fights to the death."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Thief's Retribution",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 19,
+			"traits": [
+				"Conjuration",
+				"Curse",
+				"Magical"
+			],
+			"entries": [
+				"This punishment causes you to lose something dear to you whenever you rob or steal. If you have nothing to lose, the curse exacts its punishment upon your body instead.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 39,
+						"saving throw": "Fortitude",
+						"effect": [
+							"Each time you steal something, you lose something more valuable—this item is whisked away and can’t be found again. Typically this item is one of greater monetary value, but it might be one of greater value in another sense, such as one of greater emotional value, or something you need to complete a task. If you aren’t carrying anything of greater value at the time of the theft, you lose one of your limbs instead, taking {@dice 10d6} slashing damage and losing use of that limb. The damage can’t be healed, nor the limb restored, until the stolen item is returned, even through use of spells like {@i {@spell regenerate}}."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Sword of Anathema",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": 20,
+			"traits": [
+				"Curse",
+				"Divine",
+				"Evocation"
+			],
+			"entries": [
+				"With divine intervention, followers of a deity can bestow this curse upon an enemy of the faith.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": 40,
+						"saving throw": "Will",
+						"effect": [
+							"You are marked by the deity invoked as an enemy of the church. You gain weakness 10 to damage dealt by worshippers of that deity."
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Grave Curse",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 117,
+			"level": "Level Varies",
+			"traits": [
+				"Curse",
+				"Necromancy",
+				"Magical"
+			],
+			"entries": [
+				"A grave curse punishes you for stealing from a tomb or other resting place.",
+				{
+					"type": "affliction",
+					"entries": {
+						"DC": "equal to a high spell DC for a monster of its level (page 65);",
+						"saving throw": "Will",
+						"effect": [
+							"You are hounded by undead creatures of the same level as the curse. Every night, you must attempt a DC 15 flat check. On a failure, an incorporeal undead manifests to hassle and harry you throughout the night, retreating before it can take much damage and often preventing you from gaining a full night’s rest. Whenever you enter a graveyard or other area where bodies are buried, you must succeed at the same flat check or a body animates as a corporeal undead (typically a skeleton or zombie) to attack you.",
+							"These undead are temporary and exist only to harry you; if you take control of the undead, move on, or otherwise avoid their attacks, incorporeal undead discorporate and corporeal undead collapse into ordinary corpses. The curse can be removed by returning the stolen items to their resting place."
 						]
 					}
 				}

--- a/data/afflictions.json
+++ b/data/afflictions.json
@@ -147,12 +147,12 @@
 							},
 							{
 								"stage": 2,
-								"entry": "coughing requires you to succeed at a DC 5 flat check to Cast a Spell with a verbal component or Activate an Item with a command component",
+								"entry": "coughing requires you to succeed at a DC 5 flat check to {@action Cast a Spell} with a verbal component or {@action Activate an Item} with a command component",
 								"duration": "1 week"
 							},
 							{
 								"stage": 3,
-								"entry": "{@condition fatigued}, can’t recover from the fatigued condition, and coughing requires a successful DC 15 flat check to Cast a Spell with a verbal component or Activate an Item with a command component",
+								"entry": "{@condition fatigued}, can’t recover from the fatigued condition, and coughing requires a successful DC 15 flat check to {@action Cast a Spell} with a verbal component or {@action Activate an Item} with a command component",
 								"duration": "1 week"
 							},
 							{
@@ -1006,6 +1006,230 @@
 			"entries": [
 				"An item affected by an arrow attracting curse protects you normally, but it draws ranged attacks like a magnet. Whenever a creature within 120 feet misses with a ranged attack, it must immediately reroll the attack against your AC, affecting you depending on the result of the new attack roll. The arrow attraction curse activates only if you could have been a legitimate target. Creatures that intentionally attempt to miss a ranged attack do not activate an arrow attraction curse. Once the curse has activated for the first time, the item fuses to you."
 			]
+		},
+		{
+			"name": "Arsonous",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 92,
+			"level": 7,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Evocation",
+				"Fire",
+				"Magical"
+			],
+			"usage": "curses a ring, staff, or wand",
+			"entries": [
+				"An {@i arsonous} curse creates flaws in the mystic pathways that channel magic through an item, allowing excess power to escape as sparks. Whenever you {@action activate an item||activate} the magic item, a random ally within 30 feet takes {@dice 1d10} persistent fire damage. If no ally is in range, you take the damage instead. At the GM’s discretion, this curse might ignite an unattended object or the surrounding environment instead."
+			]
+		},
+		{
+			"name": "Backbiting",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 92,
+			"level": 4,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Evocation",
+				"Magical"
+			],
+			"usage": "curses a weapon",
+			"entries": [
+				"A weapon with the {@i backbiting} curse warps space in response to catastrophic mishaps. Whenever you critically fail at a {@action Strike} with this weapon, the weapon curls around (or its projectile swerves through the air) to strike you in the back as though you hit yourself, automatically dealing maximum damage to you."
+			]
+		},
+		{
+			"name": "Bloodbiter",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 92,
+			"level": 6,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Magical",
+				"Necromancy"
+			],
+			"usage": "curses a piercing or slashing weapon",
+			"entries": [
+				"A {@i bloodbiter} weapon is awakened by violence and fueled by blood. When you make a successful attack with the weapon, it inflicts a wound that deals {@dice 1d6} {@condition persistent damage||persistent bleed damage} (in addition to its normal damage), but it also deals {@dice 1d6} {@condition persistent damage||persistent bleed damage} to you. The curse remains dormant until the weapon hits a creature, at which point black thorns protrude from the weapon and dig into your body; the weapon fuses to you and you can’t use the hand that holds the weapon for any other purpose. If the weapon is two-handed, it attaches itself to only a single hand (GM’s choice)."
+			]
+		},
+		{
+			"name": "Degenerating",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 5,
+			"traits": [
+				"Rare",
+				"Acid",
+				"Cursed",
+				"Necromancy",
+				"Magical"
+			],
+			"usage": "curses a weapon",
+			"entries": [
+				"Failure makes the weapon crumble. Whenever you critically fail an attack roll with the weapon, the {@i degenerating} curse deals {@dice 1d10} acid damage to the weapon, ignoring its Hardness and resistances."
+			]
+		},
+		{
+			"name": "Dependent",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 9,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Magical",
+				"Transmutation"
+			],
+			"usage": "curses gear used for skills or a weapon",
+			"entries": [
+				"The {@i dependent} curse makes an item function properly only under certain circumstances. Whenever you use the item to perform a skill check or use the weapon in combat, your degree of success is one worse than the result you rolled unless those specific conditions are met. The most common types of {@i dependent} curses are nocturnal or diurnal—functioning normally only at night or only during the day, respectively—but more restrictive curses do exist, such as a curse that restricts the item’s use to underground or a curse that allows the item to function effectively only during autumn."
+			]
+		},
+		{
+			"name": "Dreary",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 3,
+			"traits": [
+				"Rare",
+				"Conjuration",
+				"Cursed",
+				"Magical"
+			],
+			"usage": "curses armor",
+			"entries": [
+				"When you invest this armor, a personal-sized cloud appears over your head and begins to rain on you, and the armor fuses to you. This extinguishes uncovered flames and soaks other objects you are carrying or holding, potentially ruining them. {@book Cold Conditions|CRB|10|Temperature} are one step worse under the cloud, and at the GM’s discretion it might cause other problems, such as interfering with sleep."
+			]
+		},
+		{
+			"name": "Erratic Transposing",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 11,
+			"traits": [
+				"Rare",
+				"Conjuration",
+				"Cursed",
+				"Magical"
+			],
+			"usage": "curses a weapon",
+			"entries": [
+				"This curse bursts with uncontrolled teleportation magic when activated, unreliably transporting creatures across the battlefield. On a critical hit with the affected weapon, you and an ally within 60 feet (chosen randomly) teleport to switch places with one another. If either of the affected creatures is unable to entirely fit within its new space, the creature is placed in the nearest available squares instead."
+			]
+		},
+		{
+			"name": "Grandstanding",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 11,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Enchantment",
+				"Magical"
+			],
+			"usage": "curses a weapon",
+			"entries": [
+				"Weapons with the {@i grandstanding} curse inspire overconfidence in their wielders, demanding style over pragmatism. Whenever you reduce a foe to 0 Hit Points, you lose all remaining actions on your turn, as you are compelled to flourish, gloat, pose, or otherwise waste your time in response."
+			]
+		},
+		{
+			"name": "Overdramatic",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 5,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Evocation",
+				"Magical"
+			],
+			"usage": "curses a weapon",
+			"entries": [
+				"The weapon flashes excessive light with each attack. On a critical hit with the weapon, you are {@condition blinded} until the end of your turn and take the effects of a {@i {@spell faerie fire}} spell until the start of your next turn."
+			]
+		},
+		{
+			"name": "Raucous",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 3,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Magical",
+				"Transmutation"
+			],
+			"usage": "curses gear or a weapon",
+			"entries": [
+				"While more annoying than deadly, a {@i raucous} curse is the bane of subtlety. Whenever you use the affected item, you must loudly yell what you are attempting to do with it, ruining any attempts at stealth. Failure to announce your action or speak at an appropriate volume automatically causes the attempted action to become a critical failure."
+			]
+		},
+		{
+			"name": "Ravenous",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 1,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Evocation",
+				"Magical"
+			],
+			"usage": "curses a ring, staff, or wand",
+			"entries": [
+				"A {@i ravenous} curse draws power from the wielder’s body. Whenever you {@action activate an item||activate} the item, you become incredibly hungry and immediately begin to starve ({@book {@i Core Rulebook} 500|CRB|10|Starvation and Thirst}). You require 10 times as much food as normal for the next day."
+			]
+		},
+		{
+			"name": "Staining",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 1,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Magical",
+				"Transmutation"
+			],
+			"usage": "curses gear or a weapon",
+			"entries": [
+				"This property is associated with a specific color, which is defined at the time of the curse’s creation. Whenever you use the affected equipment while taking a {@trait manipulate} action with another object, the second object is permanently stained the associated color. For instance, if you used a set of yellow {@i staining lockpicks} to open a door, the lock would permanently become yellow. This color change does not otherwise unnaturally persist and can be changed via any normal mundane or magical means."
+			]
+		},
+		{
+			"name": "Withering",
+			"type": "Curse",
+			"source": "GMG",
+			"page": 93,
+			"level": 13,
+			"traits": [
+				"Rare",
+				"Cursed",
+				"Magical",
+				"Necromancy"
+			],
+			"usage": "curses a ring, staff, or wand",
+			"entries": [
+				"A {@i withering} curse shrivels vulnerable flesh. Whenever you {@action activate an item||activate} the item, one of your fingers turns black and falls off. You take a –1 status penalty to Thievery checks and Dexterity-based attack rolls with a hand missing two or three fingers; if you lose more than four fingers on one hand, you can’t use that hand to hold objects or use {@trait manipulate} actions. These fingers can be replaced by magic but are otherwise gone forever. The GM has the final say on how creatures with unusual appendages or numbers of fingers are affected by this curse."
+			]
 		}
+
 	]
 }


### PR DESCRIPTION
- Some of these will benefit from being linked to CRB TABLE 10–13: TEMPERATURE EFFECTS once it's in. For now they just link to the Temperature heading of pg 517
- a couple of times I decided to link to 'Activate an Item' in places where the word 'activate' is used...but not 100% sure it's called for. See the 'Ravenous' item curse for an example.
- Made minor edits to 'template' entries 'Bog Rot' and 'Curse of Nightmares'