### PR TITLE
Remove redundant "entry" values

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -4769,8 +4769,7 @@
 			"page": 300,
 			"activity": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"traits": [
 				"concentrate",
@@ -6241,8 +6240,7 @@
 			"page": 248,
 			"activity": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"traits": [
 				"exploration",

--- a/data/book/book-som.json
+++ b/data/book/book-som.json
@@ -2323,8 +2323,7 @@
 										],
 										"cast": {
 											"number": 1,
-											"unit": "day",
-											"entry": "1 day"
+											"unit": "day"
 										},
 										"cost": "magical foci worth a total value of 50 gp × the spell level × the target's level",
 										"secondaryCasters": {
@@ -2389,8 +2388,7 @@
 										],
 										"cast": {
 											"number": 1,
-											"unit": "day",
-											"entry": "1 day"
+											"unit": "day"
 										},
 										"cost": "magical foci worth 100 gp × the spell level × the node's level",
 										"secondaryCasters": {

--- a/data/items/items-aoa4.json
+++ b/data/items/items-aoa4.json
@@ -135,8 +135,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"command",

--- a/data/items/items-aoe5.json
+++ b/data/items/items-aoe5.json
@@ -399,8 +399,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",

--- a/data/items/items-aoe6.json
+++ b/data/items/items-aoe6.json
@@ -37,8 +37,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",
@@ -53,8 +52,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(Interact)"

--- a/data/items/items-apg.json
+++ b/data/items/items-apg.json
@@ -867,8 +867,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"envision",

--- a/data/items/items-av1.json
+++ b/data/items/items-av1.json
@@ -197,8 +197,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(Investigate)"

--- a/data/items/items-crb.json
+++ b/data/items/items-crb.json
@@ -5438,8 +5438,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",
@@ -5455,8 +5454,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",
@@ -10064,8 +10062,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(Interact)"
@@ -12887,8 +12884,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(envision)"
@@ -14931,8 +14927,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(envision",
@@ -16122,8 +16117,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(Interact)"
@@ -22526,8 +22520,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",

--- a/data/items/items-ec2.json
+++ b/data/items/items-ec2.json
@@ -279,8 +279,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",

--- a/data/items/items-ec6.json
+++ b/data/items/items-ec6.json
@@ -55,8 +55,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 3,
-						"unit": "day",
-						"entry": "3 days"
+						"unit": "day"
 					},
 					"components": [
 						"({@action Interact})"
@@ -475,8 +474,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",

--- a/data/items/items-frp1.json
+++ b/data/items/items-frp1.json
@@ -113,8 +113,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(envision",
@@ -162,8 +161,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes (envision,"
+						"unit": "minute"
 					},
 					"components": [
 						"Interact)"

--- a/data/items/items-frp2.json
+++ b/data/items/items-frp2.json
@@ -192,8 +192,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",

--- a/data/items/items-gmg.json
+++ b/data/items/items-gmg.json
@@ -821,8 +821,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"{@action Interact}"

--- a/data/items/items-locg.json
+++ b/data/items/items-locg.json
@@ -678,8 +678,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(envision",

--- a/data/items/items-logm.json
+++ b/data/items/items-logm.json
@@ -361,8 +361,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(command)"
@@ -397,8 +396,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(Interact)"

--- a/data/items/items-lol.json
+++ b/data/items/items-lol.json
@@ -867,8 +867,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 8,
-						"unit": "hour",
-						"entry": "8 hours"
+						"unit": "hour"
 					},
 					"components": [
 						"(envision",

--- a/data/items/items-lopsg.json
+++ b/data/items/items-lopsg.json
@@ -381,8 +381,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(command",
@@ -667,8 +666,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(Interact)"
@@ -902,8 +900,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 10,
-						"unit": "minute",
-						"entry": "10 minutes (command,"
+						"unit": "minute"
 					},
 					"components": [
 						"Interact)"

--- a/data/items/items-lotgb.json
+++ b/data/items/items-lotgb.json
@@ -2799,8 +2799,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"{@action Interact}"
@@ -4957,8 +4956,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(envision",

--- a/data/items/items-lowg.json
+++ b/data/items/items-lowg.json
@@ -93,8 +93,7 @@
 					"style": "compact",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"(Interact)"

--- a/data/items/items-som.json
+++ b/data/items/items-som.json
@@ -53,8 +53,7 @@
 					"type": "ability",
 					"activity": {
 						"number": 1,
-						"unit": "minute",
-						"entry": "1 minute"
+						"unit": "minute"
 					},
 					"components": [
 						"command",

--- a/data/rituals.json
+++ b/data/rituals.json
@@ -13,8 +13,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "amber and rare incense worth 750 gp",
 			"primaryCheck": {
@@ -99,8 +98,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "ceramics, incense, and pigments worth 100,000 gp",
 			"secondaryCasters": {
@@ -148,8 +146,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "a favorite food or drink and a wearable token with personal or familial significance worth 10 gp total",
 			"secondaryCasters": {
@@ -201,8 +198,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"primaryCheck": {
 				"skills": [
@@ -257,8 +253,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"primaryCheck": {
 				"skills": [
@@ -320,8 +315,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"primaryCheck": {
 				"skills": [
@@ -356,8 +350,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"primaryCheck": {
 				"skills": [
@@ -392,8 +385,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"secondaryCasters": {
 				"number": 4
@@ -449,8 +441,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare oils, see {@table Creature Creation Rituals|CRB|Table 7\u20131}",
 			"secondaryCasters": {
@@ -501,8 +492,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare silks worth a total value of 20 gp × the spell level",
 			"secondaryCasters": {
@@ -599,8 +589,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "one jacinth worth a total value of the target's level (minimum 1) × 5 gp, for each target",
 			"secondaryCasters": {
@@ -656,8 +645,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incense and offerings worth a total value of 20 gp × the target's level",
 			"secondaryCasters": {
@@ -719,8 +707,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "herbs, 1/5 the value on {@table Creature Creation Rituals|CRB|Table 7\u20131}",
 			"secondaryCasters": {
@@ -774,8 +761,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "crushed gems and spices worth 250 gp",
 			"secondaryCasters": {
@@ -817,8 +803,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"secondaryCasters": {
 				"number": 5,
@@ -888,8 +873,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "alchemical herbs and components worth a total of 1,000 gp × the target's level",
 			"secondaryCasters": {
@@ -946,8 +930,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"secondaryCasters": {
 				"number": 1
@@ -999,8 +982,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "rare candles and incense worth a total value of 50 gp",
 			"secondaryCasters": {
@@ -1051,8 +1033,7 @@
 			],
 			"cast": {
 				"number": 7,
-				"unit": "day",
-				"entry": "7 days"
+				"unit": "day"
 			},
 			"cost": "rare laboratory supplies and reagents worth the target's level (minimum 1) × 100 gp",
 			"secondaryCasters": {
@@ -1100,8 +1081,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incense worth a total value of 150 gp",
 			"secondaryCasters": {
@@ -1152,8 +1132,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incense worth a total value of 60 gp",
 			"secondaryCasters": {
@@ -1193,8 +1172,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare powdered pigments in at least three different colors, worth a total of 50 gp",
 			"secondaryCasters": {
@@ -1251,8 +1229,7 @@
 			],
 			"cast": {
 				"number": 6,
-				"unit": "day",
-				"entry": "6 days"
+				"unit": "day"
 			},
 			"cost": "an ornate mirror worth at least 100 gp, naturally occurring round fruit the size and number of the target's eyes, and the same amount of flawless silver needles worth at least 1 gp each",
 			"secondaryCasters": {
@@ -1310,8 +1287,7 @@
 			],
 			"cast": {
 				"number": 3,
-				"unit": "day",
-				"entry": "3 days"
+				"unit": "day"
 			},
 			"cost": "rare incense and offerings worth a total value of 20 gp × the spell level",
 			"secondaryCasters": {
@@ -1379,8 +1355,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"secondaryCasters": {
 				"number": 1
@@ -1450,8 +1425,7 @@
 			],
 			"cast": {
 				"number": 9,
-				"unit": "day",
-				"entry": "9 days"
+				"unit": "day"
 			},
 			"cost": "precious materials worth a total value of 800 gp",
 			"secondaryCasters": {
@@ -1524,8 +1498,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare oils worth 480 gp",
 			"secondaryCasters": {
@@ -1573,8 +1546,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "black onyx, see {@table Creature Creation Rituals|CRB|Table 7\u20131}",
 			"secondaryCasters": {
@@ -1627,8 +1599,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"primaryCheck": {
 				"skills": [
@@ -1664,8 +1635,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"primaryCheck": {
 				"skills": [
@@ -1704,8 +1674,7 @@
 			],
 			"cast": {
 				"number": 2,
-				"unit": "day",
-				"entry": "2 days"
+				"unit": "day"
 			},
 			"cost": "candles, specialty salts, and rare herbs worth 80 gp total",
 			"secondaryCasters": {
@@ -1771,8 +1740,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "precious metals, rare incense, and herbs worth a total value of 15 gp per spell level",
 			"primaryCheck": {
@@ -1821,8 +1789,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "magical foci worth a total value of 50 gp × the spell level × the target's level",
 			"secondaryCasters": {
@@ -1880,8 +1847,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "magical foci worth 100 gp × the spell level × the node's level",
 			"secondaryCasters": {
@@ -1937,8 +1903,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "week",
-				"entry": "1 week"
+				"unit": "week"
 			},
 			"cost": "mystical paint, elaborate veils, and powdered minerals worth 20,000 gp total",
 			"secondaryCasters": {
@@ -2004,8 +1969,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "rare oils, cold iron bells worth at least 5 gp",
 			"secondaryCasters": {
@@ -2061,8 +2025,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "valuable oils and objects associated with the target worth a total value of 100 gp × the spell level × the target's level",
 			"secondaryCasters": {
@@ -2117,8 +2080,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "water infused with a dozen deadly toxins worth a total of 50 gp",
 			"secondaryCasters": {
@@ -2176,8 +2138,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"secondaryCasters": {
 				"number": 1
@@ -2244,8 +2205,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare oils worth 10 gp × the primary caster's level",
 			"secondaryCasters": {
@@ -2295,8 +2255,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "fine wine and a set of matching rings or other tokens worth 40 gp total",
 			"secondaryCasters": {
@@ -2356,8 +2315,7 @@
 			],
 			"cast": {
 				"number": 4,
-				"unit": "hour",
-				"entry": "4 hours"
+				"unit": "hour"
 			},
 			"cost": "25 gp",
 			"secondaryCasters": {
@@ -2411,8 +2369,7 @@
 			],
 			"cast": {
 				"number": 6,
-				"unit": "day",
-				"entry": "6 days"
+				"unit": "day"
 			},
 			"cost": "crafting materials worth at least 50 gp × the target's level; a lock of hair from the target, nail clippings from the target, or a vial of blood from the target",
 			"secondaryCasters": {
@@ -2471,8 +2428,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "reagents to construct the magical prison worth a total value of 800 gp × the target's level",
 			"secondaryCasters": {
@@ -2546,8 +2502,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"primaryCheck": {
 				"mustBe": [
@@ -2583,8 +2538,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare oils worth a total value of 10 gp × the target's level",
 			"primaryCheck": {
@@ -2641,8 +2595,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incense worth a total value of 300 gp",
 			"secondaryCasters": {
@@ -2689,8 +2642,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "a pair of jeweled mirrors worth a total value of 50 gp × the level of the highest-level target",
 			"secondaryCasters": {
@@ -2754,8 +2706,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "toy carriage, horse statues, rare incense, and feathers worth 50 gp",
 			"secondaryCasters": {
@@ -2812,8 +2763,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"secondaryCasters": {
 				"number": 2
@@ -2849,8 +2799,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incense and offerings worth a total value of 2 gp × the spell level × the target's level",
 			"secondaryCasters": {
@@ -2899,8 +2848,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "warding diagram ingredients worth a total value of 2 gp × the spell level × the target's level",
 			"secondaryCasters": {
@@ -2964,8 +2912,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"secondaryCasters": {
 				"number": 1
@@ -3020,8 +2967,7 @@
 			],
 			"cast": {
 				"number": 7,
-				"unit": "day",
-				"entry": "7 days"
+				"unit": "day"
 			},
 			"cost": "splendid art supplies worth at least 100 gp × the target's level, at least one pint of blood from the target",
 			"secondaryCasters": {
@@ -3074,8 +3020,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "faerie circle ingredients worth a total value of 1 gp × the spell level × the target's level",
 			"secondaryCasters": {
@@ -3123,8 +3068,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incense and offering worth a total value of 10 gp × your level",
 			"primaryCheck": {
@@ -3165,8 +3109,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "valuable treasures from the target dragon's hoard worth a total value of 50,000 gp",
 			"primaryCheck": {
@@ -3207,8 +3150,7 @@
 			],
 			"cast": {
 				"number": 4,
-				"unit": "hour",
-				"entry": "4 hours"
+				"unit": "hour"
 			},
 			"cost": "rare herbs worth a total value of the target's level (minimum 1) × 25 gp",
 			"secondaryCasters": {
@@ -3283,8 +3225,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare oils to anoint the body worth a total value of the target's level (minimum 1) × 25 gp",
 			"secondaryCasters": {
@@ -3337,8 +3278,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "diamonds worth a total value of 75 gp × the target's level",
 			"secondaryCasters": {
@@ -3409,8 +3349,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "a piece of hair, drop of blood, or other part of the creature to be duplicated, plus rare oils, minerals, and pigments with a total value of 300 gp",
 			"secondaryCasters": {
@@ -3469,8 +3408,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"secondaryCasters": {
 				"number": 2
@@ -3525,8 +3463,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "tattoo inks and silver tattooing needles worth 20 gp for each secondary caster",
 			"secondaryCasters": {
@@ -3576,8 +3513,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incense, precious metals, and purified chalk worth 500 gp",
 			"secondaryCasters": {
@@ -3646,8 +3582,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "a bodily sample from the target, and valuables belonging to the target worth a total value of 100 gp × the spell level × the target's level",
 			"secondaryCasters": {
@@ -3747,8 +3682,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "costumes and a stage large enough to fit all casters",
 			"secondaryCasters": {
@@ -3798,8 +3732,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"cost": "rare inks and needles worth a total value of 100 gp × the spell level × the target's level (see text)",
 			"secondaryCasters": {
@@ -3855,8 +3788,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare oils, salts, and herbs worth a total value of 15 gp",
 			"secondaryCasters": {
@@ -3919,8 +3851,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "day",
-				"entry": "1 day"
+				"unit": "day"
 			},
 			"cost": "rare incenses, oils, and powdered silver, worth 150 gp total",
 			"secondaryCasters": {
@@ -3987,8 +3918,7 @@
 			],
 			"cast": {
 				"number": 7,
-				"unit": "day",
-				"entry": "7 days"
+				"unit": "day"
 			},
 			"cost": "rare oils and powdered minerals worth 5,000 gp",
 			"secondaryCasters": {

--- a/data/spells/spells-apg.json
+++ b/data/spells/spells-apg.json
@@ -1579,8 +1579,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -5142,8 +5141,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -6373,8 +6371,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[

--- a/data/spells/spells-crb.json
+++ b/data/spells/spells-crb.json
@@ -545,8 +545,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -905,8 +904,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -942,8 +940,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -1256,8 +1253,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -2786,8 +2782,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -2823,8 +2818,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -3397,8 +3391,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -3568,8 +3561,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"components": [
 				[
@@ -3649,8 +3641,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -5031,8 +5022,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -6125,8 +6115,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -6163,8 +6152,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -6260,8 +6248,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -6949,8 +6936,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -7068,8 +7054,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -7112,8 +7097,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -7660,8 +7644,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -9407,8 +9390,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -9872,8 +9854,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -10986,8 +10967,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -12256,8 +12236,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -12545,8 +12524,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -12778,8 +12756,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -13113,8 +13090,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -13298,8 +13274,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -13503,8 +13478,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -14066,8 +14040,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -14119,8 +14092,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -14831,8 +14803,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -14921,8 +14892,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -15741,8 +15711,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -16033,8 +16002,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -16369,8 +16337,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -16527,8 +16494,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -16573,8 +16539,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -16609,8 +16574,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -16732,8 +16696,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"components": [
 				[
@@ -16766,8 +16729,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -16800,8 +16762,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17058,8 +17019,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17098,8 +17058,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17227,8 +17186,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17411,8 +17369,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17453,8 +17410,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17490,8 +17446,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17716,8 +17671,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -17823,8 +17777,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -18018,8 +17971,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -18501,8 +18453,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -21220,8 +21171,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -21483,8 +21433,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -21609,8 +21558,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -22167,8 +22115,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -22519,8 +22466,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -23315,8 +23261,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -23801,8 +23746,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -23934,8 +23878,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -24467,8 +24410,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[

--- a/data/spells/spells-ec6.json
+++ b/data/spells/spells-ec6.json
@@ -171,8 +171,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[

--- a/data/spells/spells-frp1.json
+++ b/data/spells/spells-frp1.json
@@ -64,8 +64,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[

--- a/data/spells/spells-logm.json
+++ b/data/spells/spells-logm.json
@@ -1954,8 +1954,7 @@
 			],
 			"cast": {
 				"number": 5,
-				"unit": "minute",
-				"entry": "5 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -2448,8 +2447,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"range": {
 				"number": 1,
@@ -2662,8 +2660,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -2830,8 +2827,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -2874,8 +2870,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"duration": {
 				"entry": "until used or 1 minute; see text",

--- a/data/spells/spells-lol.json
+++ b/data/spells/spells-lol.json
@@ -210,8 +210,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[

--- a/data/spells/spells-som.json
+++ b/data/spells/spells-som.json
@@ -288,8 +288,7 @@
 			],
 			"cast": {
 				"number": 30,
-				"unit": "minute",
-				"entry": "30 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -819,8 +818,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -4529,8 +4527,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -4757,8 +4754,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -4896,8 +4892,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -4932,8 +4927,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "hour",
-				"entry": "1 hour"
+				"unit": "hour"
 			},
 			"components": [
 				[
@@ -5207,8 +5201,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -5675,8 +5668,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -6046,8 +6038,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -6289,8 +6280,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -7014,8 +7004,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -7051,8 +7040,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -7949,8 +7937,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[
@@ -8593,8 +8580,7 @@
 			],
 			"cast": {
 				"number": 10,
-				"unit": "minute",
-				"entry": "10 minutes"
+				"unit": "minute"
 			},
 			"components": [
 				[

--- a/data/spells/spells-sot1.json
+++ b/data/spells/spells-sot1.json
@@ -104,8 +104,7 @@
 			],
 			"cast": {
 				"number": 1,
-				"unit": "minute",
-				"entry": "1 minute"
+				"unit": "minute"
 			},
 			"components": [
 				[

--- a/data/variantrules.json
+++ b/data/variantrules.json
@@ -6528,8 +6528,7 @@
 										],
 										"cast": {
 											"number": 1,
-											"unit": "day",
-											"entry": "1 day"
+											"unit": "day"
 										},
 										"cost": "magical foci worth a total value of 50 gp × the spell level × the target's level",
 										"secondaryCasters": {
@@ -6594,8 +6593,7 @@
 										],
 										"cast": {
 											"number": 1,
-											"unit": "day",
-											"entry": "1 day"
+											"unit": "day"
 										},
 										"cost": "magical foci worth 100 gp × the spell level × the node's level",
 										"secondaryCasters": {


### PR DESCRIPTION
The renderer can produce the duration text from the data in these cases so the entry values are redundant.